### PR TITLE
Improve Fastify example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@apollo/server-integration-testsuite": "4.0.0-alpha.1",
+        "@apollo/server-integration-testsuite": "4.0.0-alpha.2",
         "@apollo/utils.withrequired": "1.0.0",
         "@jest/types": "28.1.3",
         "@types/aws-lambda": "8.10.101",
@@ -103,8 +103,9 @@
       }
     },
     "node_modules/@apollo/server": {
-      "version": "4.0.0-alpha.1",
-      "license": "MIT",
+      "version": "4.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.0.0-alpha.2.tgz",
+      "integrity": "sha512-6bq9TjsXLRIAQJg2S1GHGoihOz24XPtd6JbOZuhUHvpujfY5vZzNJHvfGgVXYvg0aiz6ywUA/GZuDipbW874iA==",
       "peer": true,
       "dependencies": {
         "@apollo/usage-reporting-protobuf": "^4.0.0-alpha.1",
@@ -119,7 +120,7 @@
         "@graphql-tools/schema": "^8.0.0",
         "@josephg/resolvable": "^1.0.0",
         "@types/express": "4.17.13",
-        "@types/express-serve-static-core": "4.17.29",
+        "@types/express-serve-static-core": "4.17.30",
         "@types/node-fetch": "^2.6.1",
         "async-retry": "^1.2.1",
         "body-parser": "^1.20.0",
@@ -140,9 +141,10 @@
       }
     },
     "node_modules/@apollo/server-integration-testsuite": {
-      "version": "4.0.0-alpha.1",
+      "version": "4.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@apollo/server-integration-testsuite/-/server-integration-testsuite-4.0.0-alpha.2.tgz",
+      "integrity": "sha512-JTVthPNczZtgcf/zD4lYjZl9m/UPmJZhbAMzZCeTHEGIKR8mBpEDHSdT+lVrgL+y1PygOa4I3LtUMHl/f5hXng==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.6.9",
         "@apollo/usage-reporting-protobuf": "^4.0.0-alpha.1",
@@ -160,7 +162,7 @@
         "node": ">=14.0"
       },
       "peerDependencies": {
-        "@apollo/server": "^4.0.0-alpha.1",
+        "@apollo/server": "^4.0.0-alpha.2",
         "@jest/globals": "28.x",
         "graphql": "^16.5.0",
         "jest": "28.x"
@@ -1388,8 +1390,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.29",
-      "license": "MIT",
+      "version": "4.17.30",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
+      "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
       "peer": true,
       "dependencies": {
         "@types/node": "*",
@@ -5291,7 +5294,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@apollo/server": "^4.0.0-alpha.1",
+        "@apollo/server": "^4.0.0-alpha.2",
         "fastify": "^4.3.0",
         "graphql": "^16.5.0"
       }
@@ -5304,7 +5307,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "@apollo/server": "^4.0.0-alpha.1",
+        "@apollo/server": "^4.0.0-alpha.2",
         "graphql": "^16.5.0"
       }
     }
@@ -5355,7 +5358,9 @@
       }
     },
     "@apollo/server": {
-      "version": "4.0.0-alpha.1",
+      "version": "4.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.0.0-alpha.2.tgz",
+      "integrity": "sha512-6bq9TjsXLRIAQJg2S1GHGoihOz24XPtd6JbOZuhUHvpujfY5vZzNJHvfGgVXYvg0aiz6ywUA/GZuDipbW874iA==",
       "peer": true,
       "requires": {
         "@apollo/usage-reporting-protobuf": "^4.0.0-alpha.1",
@@ -5370,7 +5375,7 @@
         "@graphql-tools/schema": "^8.0.0",
         "@josephg/resolvable": "^1.0.0",
         "@types/express": "4.17.13",
-        "@types/express-serve-static-core": "4.17.29",
+        "@types/express-serve-static-core": "4.17.30",
         "@types/node-fetch": "^2.6.1",
         "async-retry": "^1.2.1",
         "body-parser": "^1.20.0",
@@ -5391,7 +5396,9 @@
       }
     },
     "@apollo/server-integration-testsuite": {
-      "version": "4.0.0-alpha.1",
+      "version": "4.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@apollo/server-integration-testsuite/-/server-integration-testsuite-4.0.0-alpha.2.tgz",
+      "integrity": "sha512-JTVthPNczZtgcf/zD4lYjZl9m/UPmJZhbAMzZCeTHEGIKR8mBpEDHSdT+lVrgL+y1PygOa4I3LtUMHl/f5hXng==",
       "dev": true,
       "requires": {
         "@apollo/client": "^3.6.9",
@@ -6250,7 +6257,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.29",
+      "version": "4.17.30",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz",
+      "integrity": "sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==",
       "peer": true,
       "requires": {
         "@types/node": "*",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@apollo/server-integration-testsuite": "4.0.0-alpha.1",
+    "@apollo/server-integration-testsuite": "4.0.0-alpha.2",
     "@apollo/utils.withrequired": "1.0.0",
     "@jest/types": "28.1.3",
     "@types/aws-lambda": "8.10.101",

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -26,7 +26,7 @@
     "fastify-plugin": "^4.0.0"
   },
   "peerDependencies": {
-    "@apollo/server": "^4.0.0-alpha.1",
+    "@apollo/server": "^4.0.0-alpha.2",
     "fastify": "^4.3.0",
     "graphql": "^16.5.0"
   }

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -1,132 +1,116 @@
 import type {
   ApolloServer,
+  ApolloServerPlugin,
   BaseContext,
   ContextFunction,
   HTTPGraphQLRequest,
 } from "@apollo/server";
 import type { WithRequired } from "@apollo/utils.withrequired";
 import type {
-  FastifyPluginCallback,
+  FastifyInstance,
   FastifyReply,
   FastifyRequest,
+  RouteHandlerMethod,
 } from "fastify";
-import type { PluginMetadata } from "fastify-plugin";
-import fp from "fastify-plugin";
-
-const pluginMetadata: PluginMetadata = {
-  fastify: "4.x",
-  name: "apollo-server-integration-fastify",
-};
+import { parse as urlParse } from "url";
 
 export interface FastifyContextFunctionArgument {
   request: FastifyRequest;
   reply: FastifyReply;
 }
 
-export interface LambdaHandlerOptions<TContext extends BaseContext> {
-  context?: ContextFunction<[FastifyContextFunctionArgument], TContext>;
+export interface FastifyHandlerOptions<TContext extends BaseContext> {
+  context?:
+    | ContextFunction<[FastifyContextFunctionArgument], TContext>
+    | undefined;
 }
 
-export function fastifyPlugin(
+export function fastifyHandler(
   server: ApolloServer<BaseContext>,
-  options?: LambdaHandlerOptions<BaseContext>,
-): FastifyPluginCallback;
-export function fastifyPlugin<TContext extends BaseContext>(
+  options?: FastifyHandlerOptions<BaseContext>,
+): RouteHandlerMethod;
+export function fastifyHandler<TContext extends BaseContext>(
   server: ApolloServer<TContext>,
-  options: WithRequired<LambdaHandlerOptions<TContext>, "context">,
-): FastifyPluginCallback;
-export function fastifyPlugin(
-  server: ApolloServer<BaseContext>,
-  options?: LambdaHandlerOptions<BaseContext>,
-) {
-  return fp(fastifyHandler(server, options), pluginMetadata);
+  options: WithRequired<FastifyHandlerOptions<TContext>, "context">,
+): RouteHandlerMethod;
+export function fastifyHandler<TContext extends BaseContext>(
+  server: ApolloServer<TContext>,
+  options?: FastifyHandlerOptions<TContext>,
+): RouteHandlerMethod {
+  server.assertStarted("fastifyHandler()");
+
+  // This `any` is safe because the overload above shows that context can
+  // only be left out if you're using BaseContext as your context, and {} is a
+  // valid BaseContext.
+  const defaultContext: ContextFunction<
+    [FastifyContextFunctionArgument],
+    any
+  > = async () => ({});
+
+  const contextFunction: ContextFunction<
+    [FastifyContextFunctionArgument],
+    TContext
+  > = options?.context ?? defaultContext;
+
+  return async (request, reply) => {
+    const headers = new Map<string, string>();
+    for (const [key, value] of Object.entries(request.headers)) {
+      if (value !== undefined) {
+        headers.set(key, Array.isArray(value) ? value.join(", ") : value);
+      }
+    }
+
+    const httpGraphQLRequest: HTTPGraphQLRequest = {
+      method: request.method,
+      headers,
+      search: urlParse(request.url).search ?? "",
+      body: request.body,
+    };
+
+    const httpGraphQLResponse = await server.executeHTTPGraphQLRequest({
+      httpGraphQLRequest,
+      context: () => contextFunction({ request, reply }),
+    });
+
+    if (httpGraphQLResponse.completeBody === null) {
+      throw Error("Incremental delivery not implemented");
+    }
+
+    reply.code(httpGraphQLResponse.statusCode ?? 200);
+    reply.headers(Object.fromEntries(httpGraphQLResponse.headers));
+    reply.send(httpGraphQLResponse.completeBody);
+
+    return reply;
+  };
 }
 
-function fastifyHandler(
-  server: ApolloServer<BaseContext>,
-  options?: LambdaHandlerOptions<BaseContext>,
-): FastifyPluginCallback;
-function fastifyHandler<TContext extends BaseContext>(
-  server: ApolloServer<TContext>,
-  options: WithRequired<LambdaHandlerOptions<TContext>, "context">,
-): FastifyPluginCallback;
-function fastifyHandler<TContext extends BaseContext>(
-  server: ApolloServer<TContext>,
-  options?: LambdaHandlerOptions<TContext>,
-): FastifyPluginCallback {
-  return async (fastify) => {
-    server.assertStarted("fastifyHandler()");
-
-    // This `any` is safe because the overload above shows that context can
-    // only be left out if you're using BaseContext as your context, and {} is a
-    // valid BaseContext.
-    const defaultContext: ContextFunction<
-      [FastifyContextFunctionArgument],
-      any
-    > = async () => ({});
-
-    const contextFunction: ContextFunction<
-      [FastifyContextFunctionArgument],
-      TContext
-    > = options?.context ?? defaultContext;
-
-    fastify.removeContentTypeParser(["application/json"]);
-    fastify.addContentTypeParser(
-      "application/json",
-      { parseAs: "string" },
-      async (_request, body, _done) => {
-        try {
-          return JSON.parse(body as string);
-        } catch (err) {
-          if ((body as string).trim() === "") {
-            return {};
+// Add this plugin to your ApolloServer to drain the server during shutdown.
+// This works best with Node 18.2.0 or newer; with that version, Fastify will
+// use the new server.closeIdleConnections() to close idle connections, and the
+// plugin will close any other connections 10 seconds later. (With older Node,
+// the drain phase will hang until all connections naturally close; you can also
+// call `fastify({forceCloseConnections: true})` to make all connections immediately
+// close without grace.)
+export function fastifyDrainPlugin<TContext extends BaseContext>(
+  app: FastifyInstance,
+): ApolloServerPlugin<TContext> {
+  return {
+    async serverWillStart() {
+      return {
+        async drainServer() {
+          let timeout;
+          if ("closeAllConnections" in app.server) {
+            timeout = setTimeout(
+              () => (app.server as any).closeAllConnections(),
+              10_000,
+            );
           }
-          (err as any).statusCode = 400;
-          throw err;
-        }
-      },
-    );
-
-    // This is dumb but it gets the integration testsuite passing. We should
-    // maybe consider relaxing some of the tests in order to accommodate server
-    // frameworks that behave well or better than Apollo Server.
-    fastify.addContentTypeParser("*", (_, __, done) => {
-      done(null, null);
-    });
-
-    fastify.addHook("preHandler", async (request, reply) => {
-      const headers = new Map<string, string>();
-      for (const [key, value] of Object.entries(request.headers)) {
-        // TODO: how does fastify handle duplicate headers?
-        if (value !== undefined) {
-          headers.set(key, Array.isArray(value) ? value.join(", ") : value);
-        }
-      }
-
-      const httpGraphQLRequest: HTTPGraphQLRequest = {
-        method: request.method,
-        headers,
-        search:
-          typeof request.raw.url === "string"
-            ? request.raw.url.substring(1)
-            : "",
-        body: request.body,
+          await app.close();
+          if (timeout) {
+            clearTimeout(timeout);
+          }
+        },
       };
-
-      const httpGraphQLResponse = await server.executeHTTPGraphQLRequest({
-        httpGraphQLRequest,
-        context: () => contextFunction({ request, reply }),
-      });
-
-      if (httpGraphQLResponse.completeBody === null) {
-        throw Error("Incremental delivery not implemented");
-      }
-
-      reply.code(httpGraphQLResponse.statusCode ?? 200);
-      reply.headers(Object.fromEntries(httpGraphQLResponse.headers));
-      reply.send(httpGraphQLResponse.completeBody);
-
-      return reply;
-    });
+    },
   };
 }

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -23,7 +23,7 @@
     "node": ">=16"
   },
   "peerDependencies": {
-    "@apollo/server": "^4.0.0-alpha.1",
+    "@apollo/server": "^4.0.0-alpha.2",
     "graphql": "^16.5.0"
   }
 }


### PR DESCRIPTION
- Change plugin to be just a handler. Users get to install it where they
  want. Uses a simpler API.

- Add drain plugin.

- Fix build issue with exactOptionalPropertyTypes

- Put assertStarted in correct place.

- Decide that we did multiple header values correctly.

- Set search correctly when path is non-trivial.

- Upgrade integration suite to be more lax about certain errors; remove
  extra JSON-related code that was only there to make those tests pass.

Paired with @trevor-scheer.