### PR TITLE
Update handler name to match `startAndXYZ` convention

### DIFF
--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -27,7 +27,7 @@ export interface FastifyHandlerOptions<TContext extends BaseContext> {
 
 export function fastifyHandler(
   server: ApolloServer<BaseContext>,
-  options?: never,
+  options?: FastifyHandlerOptions<BaseContext>
 ): RouteHandlerMethod;
 export function fastifyHandler<TContext extends BaseContext>(
   server: ApolloServer<TContext>,

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -27,7 +27,7 @@ export interface FastifyHandlerOptions<TContext extends BaseContext> {
 
 export function fastifyHandler(
   server: ApolloServer<BaseContext>,
-  options?: FastifyHandlerOptions<BaseContext>,
+  options?: never,
 ): RouteHandlerMethod;
 export function fastifyHandler<TContext extends BaseContext>(
   server: ApolloServer<TContext>,

--- a/packages/lambda/src/__tests__/integration.test.ts
+++ b/packages/lambda/src/__tests__/integration.test.ts
@@ -1,5 +1,4 @@
 import { ApolloServer, ApolloServerOptions, BaseContext } from "@apollo/server";
-import { ApolloServerPluginDrainHttpServer } from "@apollo/server/plugin/drainHttpServer";
 import {
   CreateServerForIntegrationTestsOptions,
   defineIntegrationTestSuite,
@@ -7,29 +6,21 @@ import {
 import { createServer, Server } from "http";
 import type { AddressInfo } from "net";
 import { format } from "url";
-import { lambdaHandler } from "..";
+import { startAndCreateLambdaHandler } from "..";
 import { createMockServer as createAPIGatewayMockServer } from "./mockAPIGatewayServer";
 
-describe("lambdaHandler", () => {
+describe("startAndCreateLambdaHandler", () => {
   defineIntegrationTestSuite(
     async function (
       serverOptions: ApolloServerOptions<BaseContext>,
       testOptions?: CreateServerForIntegrationTestsOptions,
     ) {
       const httpServer = createServer();
-      const server = new ApolloServer({
-        ...serverOptions,
-        plugins: [
-          ...(serverOptions.plugins ?? []),
-          ApolloServerPluginDrainHttpServer({
-            httpServer,
-          }),
-        ],
-      });
+      const server = new ApolloServer(serverOptions);
 
       const handler = testOptions
-        ? lambdaHandler(server, testOptions)
-        : lambdaHandler(server);
+        ? startAndCreateLambdaHandler(server, testOptions)
+        : startAndCreateLambdaHandler(server);
 
       httpServer.addListener("request", createAPIGatewayMockServer(handler));
 
@@ -37,7 +28,13 @@ describe("lambdaHandler", () => {
         httpServer.listen({ port: 0 }, resolve);
       });
 
-      return { server, url: urlForHttpServer(httpServer) };
+      return {
+        server,
+        url: urlForHttpServer(httpServer),
+        extraCleanup: async () => {
+          httpServer.close();
+        },
+      };
     },
     {
       serverIsStartedInBackground: true,

--- a/packages/lambda/src/__tests__/integration.test.ts
+++ b/packages/lambda/src/__tests__/integration.test.ts
@@ -6,10 +6,10 @@ import {
 import { createServer, Server } from "http";
 import type { AddressInfo } from "net";
 import { format } from "url";
-import { startAndCreateLambdaHandler } from "..";
+import { startServerAndCreateLambdaHandler } from "..";
 import { createMockServer as createAPIGatewayMockServer } from "./mockAPIGatewayServer";
 
-describe("startAndCreateLambdaHandler", () => {
+describe("startServerAndCreateLambdaHandler", () => {
   defineIntegrationTestSuite(
     async function (
       serverOptions: ApolloServerOptions<BaseContext>,
@@ -19,8 +19,8 @@ describe("startAndCreateLambdaHandler", () => {
       const server = new ApolloServer(serverOptions);
 
       const handler = testOptions
-        ? startAndCreateLambdaHandler(server, testOptions)
-        : startAndCreateLambdaHandler(server);
+        ? startServerAndCreateLambdaHandler(server, testOptions)
+        : startServerAndCreateLambdaHandler(server);
 
       httpServer.addListener("request", createAPIGatewayMockServer(handler));
 

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -25,15 +25,18 @@ type LambdaHandler = Handler<
   APIGatewayProxyStructuredResultV2
 >;
 
-export function lambdaHandler(
+// Following the naming convention "startAndXYZ" for serverless handlers in the
+// Apollo Server docs so that it's clear the server will be started when this
+// function is called and the user should not call `start` themselves.
+export function startAndCreateLambdaHandler(
   server: ApolloServer<BaseContext>,
   options?: LambdaHandlerOptions<BaseContext>,
 ): LambdaHandler;
-export function lambdaHandler<TContext extends BaseContext>(
+export function startAndCreateLambdaHandler<TContext extends BaseContext>(
   server: ApolloServer<TContext>,
   options: WithRequired<LambdaHandlerOptions<TContext>, "context">,
 ): LambdaHandler;
-export function lambdaHandler<TContext extends BaseContext>(
+export function startAndCreateLambdaHandler<TContext extends BaseContext>(
   server: ApolloServer<TContext>,
   options?: LambdaHandlerOptions<TContext>,
 ): LambdaHandler {
@@ -54,33 +57,19 @@ export function lambdaHandler<TContext extends BaseContext>(
 
   return async function (event, context) {
     let parsedBody: object | string | undefined = undefined;
-    try {
-      if (!event.body) {
-        // assert there's a query string?
-      } else if (event.headers["content-type"] === "application/json") {
-        try {
-          parsedBody = JSON.parse(event.body);
-        } catch (e: unknown) {
-          return {
-            statusCode: 400,
-            body: (e as Error).message,
-          };
-        }
-      } else if (event.headers["content-type"] === "text/plain") {
-        parsedBody = event.body;
+    if (!event.body) {
+      // assert there's a query string?
+    } else if (event.headers["content-type"] === "application/json") {
+      try {
+        parsedBody = JSON.parse(event.body);
+      } catch (e: unknown) {
+        return {
+          statusCode: 400,
+          body: (e as Error).message,
+        };
       }
-    } catch (error: unknown) {
-      // The json body-parser *always* sets req.body to {} if it's unset (even
-      // if the Content-Type doesn't match), so if it isn't set, you probably
-      // forgot to set up body-parser. (Note that this may change in the future
-      // body-parser@2.)
-      // return {
-      //   statusCode: 500,
-      //   body:
-      //     '`event.body` is not set; this probably means you forgot to set up the ' +
-      //     '`body-parser` middleware before the Apollo Server middleware.',
-      // };
-      throw error;
+    } else if (event.headers["content-type"] === "text/plain") {
+      parsedBody = event.body;
     }
 
     const headers = new Map<string, string>();

--- a/packages/lambda/src/index.ts
+++ b/packages/lambda/src/index.ts
@@ -28,15 +28,15 @@ type LambdaHandler = Handler<
 // Following the naming convention "startAndXYZ" for serverless handlers in the
 // Apollo Server docs so that it's clear the server will be started when this
 // function is called and the user should not call `start` themselves.
-export function startAndCreateLambdaHandler(
+export function startServerAndCreateLambdaHandler(
   server: ApolloServer<BaseContext>,
   options?: LambdaHandlerOptions<BaseContext>,
 ): LambdaHandler;
-export function startAndCreateLambdaHandler<TContext extends BaseContext>(
+export function startServerAndCreateLambdaHandler<TContext extends BaseContext>(
   server: ApolloServer<TContext>,
   options: WithRequired<LambdaHandlerOptions<TContext>, "context">,
 ): LambdaHandler;
-export function startAndCreateLambdaHandler<TContext extends BaseContext>(
+export function startServerAndCreateLambdaHandler<TContext extends BaseContext>(
   server: ApolloServer<TContext>,
   options?: LambdaHandlerOptions<TContext>,
 ): LambdaHandler {


### PR DESCRIPTION
Additional minor cleanup, fix tests not shutting down correctly.